### PR TITLE
修復浮點數序列化精度問題

### DIFF
--- a/body/BodyBase.cs
+++ b/body/BodyBase.cs
@@ -5,10 +5,13 @@ namespace AutoNai3Tools.body {
         public virtual string prompt { get; set; }
         public BodyBase(Dictionary<string, object> kwargs) { }
 
-        public string ToJson() {
-            return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonSerializerSettings {
-                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore
-            });
-        }
+    public string ToJson() {
+        return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonSerializerSettings {
+            NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+            FloatFormatHandling = Newtonsoft.Json.FloatFormatHandling.DefaultValue,
+            FloatParseHandling = Newtonsoft.Json.FloatParseHandling.Double,
+            Formatting = Newtonsoft.Json.Formatting.None
+        });
+    }
     }
 }

--- a/body/NovalAIBase.cs
+++ b/body/NovalAIBase.cs
@@ -128,7 +128,7 @@ namespace AutoNai3Tools.body {
         public double controlnet_strength { get; set; }
         public bool legacy { get; set; }
         public bool add_original_image { get; set; }
-        public double cfg_rescale { get; set; }
+        public float cfg_rescale { get; set; }
         public string noise_schedule { get; set; }
         public string image { get; set; }
         public float? strength { get; set; }

--- a/utils/NovalAi.cs
+++ b/utils/NovalAi.cs
@@ -18,7 +18,12 @@ using AutoNai3Tools.body;
 namespace AutoNai3Tools.utils {
     class Nai3Body {
         public string ToJson() {
-            return Newtonsoft.Json.JsonConvert.SerializeObject(this);
+            return Newtonsoft.Json.JsonConvert.SerializeObject(this, new Newtonsoft.Json.JsonSerializerSettings {
+                NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
+                FloatFormatHandling = Newtonsoft.Json.FloatFormatHandling.DefaultValue,
+                FloatParseHandling = Newtonsoft.Json.FloatParseHandling.Double,
+                Formatting = Newtonsoft.Json.Formatting.None
+            });
         }
     }
 
@@ -56,7 +61,7 @@ namespace AutoNai3Tools.utils {
         public bool legacy { get; set; } = false;
         public bool add_original_image { get; set; } = true;
         public int uncond_scale { get; set; } = 1;
-        public float cfg_rescale { get; set; } = 0;
+        public float cfg_rescale { get; set; } = 0f;
         public string noise_schedule { get; set; } = "karras";
         public bool legacy_v3_extend { get; set; } = false;
         public string image { get; set; } = null;
@@ -90,7 +95,7 @@ namespace AutoNai3Tools.utils {
             bool legacy = false,
             bool add_original_image = true,
             int uncond_scale = 1,
-            float cfg_rescale = 0,
+            float cfg_rescale = 0f,
             string noise_schedule = "karras",
             bool legacy_v3_extend = false,
             string image = null,


### PR DESCRIPTION
- 修改JSON序列化設置，控制浮點數的顯示格式
- 統一使用float類型表示cfg_rescale屬性
- 明確指定浮點數字面量類型為float (0f)
- 確保所有序列化方法使用相同的設置

這些修改解決了CFG值為0.3時，實際顯示為0.300000000000000很長一串數字的問題。